### PR TITLE
Peek set url before doing calling options.before

### DIFF
--- a/lib/hounds.js
+++ b/lib/hounds.js
@@ -74,6 +74,7 @@ module.exports = (options) => {
         }
 
         if (options.before && !kickOff) {
+            url = queue[0]
             options.before(nightmare).then(processNextInQueue)
             return
         }


### PR DESCRIPTION
Otherwise url is unset or off by one if an error is reported during the before.